### PR TITLE
fix: correct method calls in conditional checks

### DIFF
--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -311,15 +311,15 @@ class FilamentEditProfilePlugin implements Plugin
             $components->put('edit_password_form', EditPasswordForm::class);
         }
 
-        if ($this->shouldShowDeleteAccountForm) {
+        if ($this->getShouldShowDeleteAccountForm()) {
             $components->put('delete_account_form', DeleteAccountForm::class);
         }
 
-        if ($this->sanctumTokens) {
+        if ($this->getShouldShowSanctumTokens()) {
             $components->put('sanctum_tokens', SanctumTokens::class);
         }
 
-        if ($this->shouldShowBrowserSessionsForm) {
+        if ($this->getShouldShowBrowserSessionsForm()) {
             $components->put('browser_sessions_form', BrowserSessionsForm::class);
         }
 


### PR DESCRIPTION
Replaced property access with corresponding getter methods for conditional checks to ensure proper closure evaluation and consistent behavior across different conditions.
