### PR TITLE
Add disk and visibility configuration for avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ use Joaopaulolndev\FilamentEditProfile\Pages\EditProfilePage;
 ])
 ```
 
+If needed you can define the disk and visibility of the avatar image. In the config file add the following:
+
+[config/filament-edit-profile.php](config/filament-edit-profile.php)
+
+```php
+return [
+    'disk' => 's3',
+    'visibility' => 'public',
+];
+```
+
+
 ## Profile Avatar
 
 ![Screenshot of avatar Feature](https://raw.githubusercontent.com/joaopaulolndev/filament-edit-profile/main/art/profile-avatar.png)

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -43,6 +43,8 @@ class EditProfileForm extends BaseProfileForm
                             ->label(__('filament-edit-profile::default.avatar'))
                             ->avatar()
                             ->imageEditor()
+                            ->disk(config('filament-edit-profile.disk', 'public'))
+                            ->visibility(config('filament-edit-profile.visibility', 'public'))
                             ->directory(filament('filament-edit-profile')->getAvatarDirectory())
                             ->rules(filament('filament-edit-profile')->getAvatarRules())
                             ->hidden(! filament('filament-edit-profile')->getShouldShowAvatarForm()),


### PR DESCRIPTION
Enhanced the avatar upload feature by allowing customization of the storage disk and visibility settings via configuration. Updated the README to reflect these new options and provide implementation guidance.

In the EditProfileForm.php added the 2 new directives in the FileUpload

```php
 FileUpload::make('avatar_url')
    ->label(__('filament-edit-profile::default.avatar'))
    ->avatar()
    ->imageEditor()
    ->disk(config('filament-edit-profile.disk', 'public')) /*new disk directive*/
    ->visibility(config('filament-edit-profile.visibility', 'public')) /*new visibility directive*/
    ->directory(filament('filament-edit-profile')->getAvatarDirectory())
    ->rules(filament('filament-edit-profile')->getAvatarRules())
    ->hidden(! filament('filament-edit-profile')->getShouldShowAvatarForm()
),
```

in the config/filament-edit-profile.php 

```php
return [
    'disk' => 's3',
    'visibility' => 'public',
];
```

Updated the Readme.md to reflect this option

