### PR TITLE
Fix `json_decode` type error

### DIFF
--- a/src/Livewire/CustomFieldsForm.php
+++ b/src/Livewire/CustomFieldsForm.php
@@ -32,7 +32,7 @@ class CustomFieldsForm extends BaseProfileForm
 
         $this->customFields = config('filament-edit-profile.custom_fields');
 
-        $this->form->fill(json_decode($data['custom_fields'], true) ?? []);
+        $this->form->fill($data['custom_fields'] ?? []);
     }
 
     public function form(Form $form): Form


### PR DESCRIPTION
Purpose: This PR addresses an issue with the json_decode() function.

Issue: During runtime, the json_decode() function was receiving an array type input instead of the expected string type for JSON data. This led to the following error message:

    json_decode(): Argument #1 ($json) must be of type string, array given

Solution: The first argument of the json_decode() function has been updated to ensure it receives a valid string type JSON input. As a result, the error message has been resolved, and the associated functionality now operates correctly.

Changes:

    Corrected the erroneous json_decode() call.

Note: The changes made do not affect existing functionality and have been verified to provide the expected output. The solution is included in commit 28f785e441f44e0a0ffeba6fc22d2ca1348f10d2.