### PR TITLE
Refactor Configuration for Filament Profile Editing and Avatar Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ protected $fillable = [
     'name',
     'email',
     'password',
-    'avatar_url',
+    'avatar_url', // or column name according to config('filament-edit-profile.avatar_column', 'avatar_url')
 ];
 ```
 
@@ -162,7 +162,8 @@ class User extends Authenticatable implements HasAvatar
     // ...
     public function getFilamentAvatarUrl(): ?string
     {
-        return $this->avatar_url ? Storage::url("$this->avatar_url") : null;
+        $avatarColumn = config('filament-edit-profile.avatar_column', 'avatar_url');
+        return $this->$avatarColumn ? Storage::url("$this->$avatarColumn") : null;
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ If needed you can define the disk and visibility of the avatar image. In the con
 
 ```php
 return [
-    'disk' => 's3',
-    'visibility' => 'public',
+    'disk' => env('FILESYSTEM_DISK', 'public'),
+    'visibility' => 'public', // or replace by filesystem disk visibility with fallback value
 ];
 ```
 

--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-
+    'disk' => env('FILESYSTEM_DISK', 'public'),
+    'visibility' => 'public', // or replace by filesystem disk visibility with fallback value
 ];

--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'avatar_column' => 'avatar_url',
     'disk' => env('FILESYSTEM_DISK', 'public'),
     'visibility' => 'public', // or replace by filesystem disk visibility with fallback value
 ];

--- a/database/migrations/add_avatar_url_to_users_table.php.stub
+++ b/database/migrations/add_avatar_url_to_users_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('avatar_url')->nullable();
+            $table->string(config('filament-edit-profile.avatar_column', 'avatar_url'))->nullable();
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('avatar_url');
+            $table->dropColumn(config('filament-edit-profile.avatar_column', 'avatar_url'));
         });
     }
 };

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -28,7 +28,7 @@ class EditProfileForm extends BaseProfileForm
 
         $this->userClass = get_class($this->user);
 
-        $this->form->fill($this->user->only('avatar_url', 'name', 'email'));
+        $this->form->fill($this->user->only(config('filament-edit-profile.avatar_column', 'avatar_url'), 'name', 'email'));
     }
 
     public function form(Form $form): Form
@@ -39,7 +39,7 @@ class EditProfileForm extends BaseProfileForm
                     ->aside()
                     ->description(__('filament-edit-profile::default.profile_information_description'))
                     ->schema([
-                        FileUpload::make('avatar_url')
+                        FileUpload::make(config('filament-edit-profile.avatar_column', 'avatar_url'))
                             ->label(__('filament-edit-profile::default.avatar'))
                             ->avatar()
                             ->imageEditor()


### PR DESCRIPTION
Changes Introduced:

1. **Default Configuration Update:**
   - Added a default configuration in `filament-edit-profile.php`.
   - Updated the `README.md` with configuration examples for clarity.

2. **Filesystem Configuration:**
   - Now uses the `FILESYSTEM_DISK` environment variable to match the application's default filesystem disk.
   - Set fallback to `'public'` instead of `'local'` to prevent breaking changes in existing installations.
   - Configured default `visibility` as `'public'` with comments explaining it can be customized if needed.

3. **Avatar Configuration:**
   - Introduced configuration for specifying the avatar column name, defaulting to `'avatar_url'`.
   - Updated the `README.md` to reflect this new configuration option.
