### PR TITLE
Feat: Add more property support to custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,47 +294,87 @@ return [
     'show_custom_fields' => true,
     'custom_fields' => [
         'custom_field_1' => [
-            'type' => 'text',
-            'label' => 'Custom Textfield 1',
-            'placeholder' => 'Custom Field 1',
-            'required' => true,
-            'rules' => 'required|string|max:255',
+            'type' => 'text', // required
+            'label' => 'Custom Textfield 1', // required
+            'placeholder' => 'Custom Field 1', // optional
+            'required' => true, // optional
+            'rules' => [], // optional
+            'hintIcon' => '', // optional
+            'hint' => '', // optional
+            'suffix_icon' => '', // optional
+            'prefix_icon' => '', // optional
+            'default' => '', // optional
+            'column_span' => 'full', // optional
         ],
         'custom_field_2' => [
-            'type' => 'password',
-            'label' => 'Custom Password field 2',
-            'placeholder' => 'Custom Password Field 2',
-            'required' => true,
-            'rules' => 'required|string|max:255',
+            'type' => 'password', // required
+            'label' => 'Custom Password field 2', // required
+            'placeholder' => 'Custom Password Field 2', // optional
+            'required' => true, // optional
+            'rules' => [], // optional
+            'hintIcon' => '', // optional
+            'hint' => '', // optional
+            'default' => '', // optional
+            'column_span' => 'full',
+            'revealable' => true, // optional
         ],
         'custom_field_3' => [
-            'type' => 'select',
-            'label' => 'Custom Select 3',
-            'placeholder' => 'Select',
-            'required' => true,
+            'type' => 'select', // required
+            'label' => 'Custom Select 3', // required
+            'placeholder' => 'Select', // optional
+            'required' => true, // optional
             'options' => [
                 'option_1' => 'Option 1',
                 'option_2' => 'Option 2',
                 'option_3' => 'Option 3',
-            ],
+            ], // optional
+            'selectable_placeholder' => true // optional
+            'native' => true // optional
+            'preload' => true // optional
+            'suffix_icon' => '', // optional
+            'default' => '', // optional
+            'searchable' => true, // optional
+            'column_span' => 'full', // optional
+            'rules' => [], // optional
         ],
         'custom_field_4' => [
-            'type' =>'textarea',
-            'label' => 'Custom Textarea 4',
-            'placeholder' => 'Textarea',
-            'rows' => '3',
-            'required' => true,
+            'type' =>'textarea', // required
+            'label' => 'Custom Textarea 4', // required
+            'placeholder' => 'Textarea', // optional
+            'rows' => '3', // optional
+            'required' => true, // optional
+            'hint_icon' => '', // optional
+            'hint' => '', // optional
+            'default' => '', // optional
+            'rules' => [], // optional
+            'column_span' => 'full', // optional
         ],
         'custom_field_5' => [
-            'type' => 'datetime',
-            'label' => 'Custom Datetime 5',
-            'placeholder' => 'Datetime',
-            'seconds' => false,
+            'type' => 'datetime', // required
+            'label' => 'Custom Datetime 5', // required
+            'placeholder' => 'Datetime', // optional
+            'seconds' => false, // optional
+            'required' => true, // optional
+            'hint_icon' => '', // optional
+            'hint' => '', // optional
+            'default' => '', // optional
+            'suffix_icon' => '', // optional
+            'prefix_icon' => '', // optional
+            'rules' => [], // optional
+            'format' => 'Y-m-d H:i:s', // optional
+            'time' => true, // optional
+            'native' => true, // optional
+            'column_span' => 'full', // optional
         ],
         'custom_field_6' => [
-            'type' => 'boolean',
-            'label' => 'Custom Boolean 6',
-            'placeholder' => 'Boolean'
+            'type' => 'boolean', // required
+            'label' => 'Custom Boolean 6', // required
+            'placeholder' => 'Boolean', // optional
+            'hint_icon' => '', // optional
+            'hint' => '', // optional
+            'default' => '', // optional
+            'rules' => [], // optional
+            'column_span' => 'full', // optional
         ],
     ]
 ];

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ return [
             'prefix_icon' => '', // optional
             'default' => '', // optional
             'column_span' => 'full', // optional
+            'autocomplete' => false, // optional
         ],
         'custom_field_2' => [
             'type' => 'password', // required
@@ -317,6 +318,7 @@ return [
             'default' => '', // optional
             'column_span' => 'full',
             'revealable' => true, // optional
+            'autocomplete' => true, // optional
         ],
         'custom_field_3' => [
             'type' => 'select', // required
@@ -336,6 +338,8 @@ return [
             'searchable' => true, // optional
             'column_span' => 'full', // optional
             'rules' => [], // optional
+            'hint_icon' => '', // optional
+            'hint' => '', // optional
         ],
         'custom_field_4' => [
             'type' =>'textarea', // required

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ return [
             'placeholder' => 'Custom Field 1', // optional
             'required' => true, // optional
             'rules' => [], // optional
-            'hintIcon' => '', // optional
+            'hint_icon' => '', // optional
             'hint' => '', // optional
             'suffix_icon' => '', // optional
             'prefix_icon' => '', // optional
@@ -313,7 +313,7 @@ return [
             'placeholder' => 'Custom Password Field 2', // optional
             'required' => true, // optional
             'rules' => [], // optional
-            'hintIcon' => '', // optional
+            'hint_icon' => '', // optional
             'hint' => '', // optional
             'default' => '', // optional
             'column_span' => 'full',

--- a/src/Livewire/CustomFieldsForm.php
+++ b/src/Livewire/CustomFieldsForm.php
@@ -49,6 +49,7 @@ class CustomFieldsForm extends BaseProfileForm
                 Forms\Components\Section::make(__('filament-edit-profile::default.custom_fields'))
                     ->aside()
                     ->description(__('filament-edit-profile::default.custom_fields_description'))
+                    ->columns()
                     ->schema($fields),
             ])
             ->model($this->getUser())
@@ -84,9 +85,10 @@ class CustomFieldsForm extends BaseProfileForm
 
             return $class::make($fieldKey)
                 ->label(__($field['label']))
-                ->placeholder(__($field['placeholder']))
-                ->required($field['required'])
-                ->rules($field['rules']);
+                ->placeholder(__($field['placeholder'] ?? null))
+                ->required($field['required'] ?? false)
+                ->columnSpan($field['column_span'] ?? 'full')
+                ->rules($field['rules'] ?? []);
 
         } catch (Throwable $exception) {
         }
@@ -96,51 +98,92 @@ class CustomFieldsForm extends BaseProfileForm
     {
         return TextInput::make($fieldKey)
             ->label(__($field['label']))
-            ->placeholder(__($field['placeholder']))
-            ->required($field['required'])
-            ->rules($field['rules']);
+            ->placeholder(__($field['placeholder'] ?? null))
+            ->required($field['required'] ?? false)
+            ->hintIcon($field['hint_icon'] ?? null)
+            ->hint(__($field['hint'] ?? null))
+            ->suffixIcon($field['suffix_icon'] ?? null)
+            ->prefixIcon($field['prefix_icon'] ?? null)
+            ->default($field['default'] ?? null)
+            ->rules($field['rules'] ?? [])
+            ->columnSpan($field['column_span'] ?? 'full');
     }
 
     private static function createPasswordInput(string $fieldKey, array $field): TextInput
     {
         return TextInput::make($fieldKey)
             ->label(__($field['label']))
-            ->placeholder(__($field['placeholder']))
-            ->required($field['required'])
+            ->placeholder(__($field['placeholder'] ?? null))
+            ->hintIcon($field['hint_icon'] ?? null)
+            ->hint(__($field['hint'] ?? null))
+            ->required($field['required'] ?? false)
+            ->revealable($field['revealable'] ?? true)
             ->password()
-            ->rules($field['rules']);
+            ->default($field['default'] ?? null)
+            ->rules($field['rules'] ?? [])
+            ->columnSpan($field['column_span'] ?? 'full');
     }
 
     private static function createCheckbox(string $fieldKey, array $field): Checkbox
     {
         return Checkbox::make($fieldKey)
-            ->label(__($field['label']));
+            ->label(__($field['label']))
+            ->required($field['required'] ?? false)
+            ->hintIcon($field['hint_icon'] ?? null)
+            ->hint(__($field['hint'] ?? null))
+            ->default($field['default'] ?? null)
+            ->rules($field['rules'] ?? [])
+            ->columnSpan($field['column_span'] ?? 'full');
     }
 
     private static function createSelect(string $fieldKey, array $field): Select
     {
         return Select::make($fieldKey)
             ->label(__($field['label']))
-            ->placeholder(__($field['placeholder']))
-            ->options($field['options'])
-            ->required($field['required']);
+            ->placeholder(__($field['placeholder'] ?? null))
+            ->options($field['options'] ?? [])
+            ->required($field['required'] ?? false)
+            ->selectablePlaceholder($field['selectable_placeholder'] ?? true)
+            ->native($field['native'] ?? true)
+            ->preload($field['preload'] ?? true)
+            ->suffixIcon($field['suffix_icon'] ?? null)
+            ->default($field['default'] ?? null)
+            ->searchable($field['searchable'] ?? true)
+            ->columnSpan($field['column_span'] ?? 'full')
+            ->rules($field['rules'] ?? []);
     }
 
     private static function createTextarea(string $fieldKey, array $field): Textarea
     {
         return Textarea::make($fieldKey)
             ->label(__($field['label']))
-            ->placeholder(__($field['placeholder']))
-            ->rows($field['rows'])
-            ->required($field['required']);
+            ->placeholder(__($field['placeholder'] ?? null))
+            ->required($field['required'] ?? false)
+            ->hintIcon($field['hint_icon'] ?? null)
+            ->hint(__($field['hint'] ?? null))
+            ->default($field['default'] ?? null)
+            ->rules($field['rules'] ?? [])
+            ->rows($field['rows'] ?? 3)
+            ->columnSpan($field['column_span'] ?? 'full');
     }
 
     private static function createDateTimePicker(string $fieldKey, array $field): DateTimePicker
     {
         return DateTimePicker::make($fieldKey)
             ->label(__($field['label']))
-            ->placeholder(__($field['placeholder']))
-            ->seconds($field['seconds']);
+            ->placeholder(__($field['placeholder'] ?? null))
+            ->required($field['required'] ?? false)
+            ->hintIcon($field['hint_icon'] ?? null)
+            ->hint(__($field['hint'] ?? null))
+            ->suffixIcon($field['suffix_icon'] ?? null)
+            ->prefixIcon($field['prefix_icon'] ?? null)
+            ->default($field['default'] ?? null)
+            ->rules($field['rules'] ?? [])
+            ->format($field['format'] ?? 'Y-m-d H:i:s')
+            ->time($field['time'] ?? true)
+            ->native($field['native'] ?? true)
+            ->columnSpan($field['column_span'] ?? 'full')
+            ->seconds($field['seconds'] ?? true);
     }
 
     public function updateCustomFields(): void

--- a/src/Livewire/CustomFieldsForm.php
+++ b/src/Livewire/CustomFieldsForm.php
@@ -106,6 +106,7 @@ class CustomFieldsForm extends BaseProfileForm
             ->prefixIcon($field['prefix_icon'] ?? null)
             ->default($field['default'] ?? null)
             ->rules($field['rules'] ?? [])
+            ->autocomplete($field['autocomplete'] ?? false)
             ->columnSpan($field['column_span'] ?? 'full');
     }
 
@@ -118,6 +119,7 @@ class CustomFieldsForm extends BaseProfileForm
             ->hint(__($field['hint'] ?? null))
             ->required($field['required'] ?? false)
             ->revealable($field['revealable'] ?? true)
+            ->autocomplete($field['autocomplete'] ?? true)
             ->password()
             ->default($field['default'] ?? null)
             ->rules($field['rules'] ?? [])
@@ -150,6 +152,8 @@ class CustomFieldsForm extends BaseProfileForm
             ->default($field['default'] ?? null)
             ->searchable($field['searchable'] ?? true)
             ->columnSpan($field['column_span'] ?? 'full')
+            ->hint($field['hint'] ?? null)
+            ->hintIcon($field['hint_icon'] ?? null)
             ->rules($field['rules'] ?? []);
     }
 


### PR DESCRIPTION
This pull request will add more options to custom field types and add default values to non-required fields so it doesn't throw an `undefined array key`. 

It will also update the README file to include all the new supported options for each field. 

A sample image of all the fields and some of the new features when enabled: 

![image](https://github.com/user-attachments/assets/5a296874-1ce2-4511-8717-072bd45e743e)

This is all the new supported properties:

```
return [
    'show_custom_fields' => true,
    'custom_fields' => [
        'custom_field_1' => [
            'type' => 'text', // required
            'label' => 'Custom Textfield 1', // required
            'placeholder' => 'Custom Field 1', // optional
            'required' => true, // optional
            'rules' => [], // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
            'suffix_icon' => '', // optional
            'prefix_icon' => '', // optional
            'default' => '', // optional
            'column_span' => 'full', // optional
            'autocomplete' => false, // optional
        ],
        'custom_field_2' => [
            'type' => 'password', // required
            'label' => 'Custom Password field 2', // required
            'placeholder' => 'Custom Password Field 2', // optional
            'required' => true, // optional
            'rules' => [], // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
            'default' => '', // optional
            'column_span' => 'full',
            'revealable' => true, // optional
            'autocomplete' => true, // optional
        ],
        'custom_field_3' => [
            'type' => 'select', // required
            'label' => 'Custom Select 3', // required
            'placeholder' => 'Select', // optional
            'required' => true, // optional
            'options' => [
                'option_1' => 'Option 1',
                'option_2' => 'Option 2',
                'option_3' => 'Option 3',
            ], // optional
            'selectable_placeholder' => true // optional
            'native' => true // optional
            'preload' => true // optional
            'suffix_icon' => '', // optional
            'default' => '', // optional
            'searchable' => true, // optional
            'column_span' => 'full', // optional
            'rules' => [], // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
        ],
        'custom_field_4' => [
            'type' =>'textarea', // required
            'label' => 'Custom Textarea 4', // required
            'placeholder' => 'Textarea', // optional
            'rows' => '3', // optional
            'required' => true, // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
            'default' => '', // optional
            'rules' => [], // optional
            'column_span' => 'full', // optional
        ],
        'custom_field_5' => [
            'type' => 'datetime', // required
            'label' => 'Custom Datetime 5', // required
            'placeholder' => 'Datetime', // optional
            'seconds' => false, // optional
            'required' => true, // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
            'default' => '', // optional
            'suffix_icon' => '', // optional
            'prefix_icon' => '', // optional
            'rules' => [], // optional
            'format' => 'Y-m-d H:i:s', // optional
            'time' => true, // optional
            'native' => true, // optional
            'column_span' => 'full', // optional
        ],
        'custom_field_6' => [
            'type' => 'boolean', // required
            'label' => 'Custom Boolean 6', // required
            'placeholder' => 'Boolean', // optional
            'hint_icon' => '', // optional
            'hint' => '', // optional
            'default' => '', // optional
            'rules' => [], // optional
            'column_span' => 'full', // optional
        ],
    ]
];
```