### PR TITLE
Support Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,8 +33,6 @@ jobs:
             laravel: 12.*
           - php: 8.2
             laravel: 12.*
-          - laravel: 12.*
-            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,10 +37,6 @@ jobs:
             pestphp/pest-plugin-laravel: 3.*
         exclude:
           - php: 8.1
-            laravel: 10.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.2
             laravel: 12.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2, 8.1]
-        laravel: [11.*, 10.*]
+        laravel: [12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -23,9 +23,18 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
             carbon: 3.*
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: 3.*
         exclude:
           - php: 8.1
             laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+          - php: 8.2
+            laravel: 12.*
+          - laravel: 12.*
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,6 +38,12 @@ jobs:
         exclude:
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.3
+            laravel: 10.*
+          - php: 8.2
+            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,17 +20,26 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: 2.*
+            pestphp/pest: 2.*
+            pestphp/pest-plugin-arch: 2.*
+            pestphp/pest-plugin-laravel: 2.*
           - laravel: 11.*
             testbench: 9.*
             carbon: 3.*
+            pestphp/pest: 2.*
+            pestphp/pest-plugin-arch: 2.*
+            pestphp/pest-plugin-laravel: 2.*
           - laravel: 12.*
             testbench: 10.*
             carbon: 3.*
+            pestphp/pest: 3.*
+            pestphp/pest-plugin-arch: 3.*
+            pestphp/pest-plugin-laravel: 3.*
         exclude:
           - php: 8.1
-            laravel: 11.*
+            laravel: 10.*
           - php: 8.1
-            laravel: 12.*
+            laravel: 11.*
           - php: 8.2
             laravel: 12.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 phpstan.neon
 testbench.yaml
 vendor
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require-dev": {
         "laradumps/laradumps": "^3.1",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9|^8.0",
-        "orchestra/testbench": "^8.0|^9.0",
+        "nunomaduro/collision": "^7.9|^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^2.1",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "laradumps/laradumps": "^3.1",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9|^8.0|^9.0",
+        "nunomaduro/collision": "^7.9|^8.6",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^3.4.7",
         "pestphp/pest-plugin-arch": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.9|^8.0|^9.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.1",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0"
+        "pestphp/pest": "^3.4.7",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.9|^8.6",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^3.4.7",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.1.0"
+        "pestphp/pest": "^2.1|^3.4.7",
+        "pestphp/pest-plugin-arch": "^2.0|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Update PHP requirement to ^8.2 in composer.json
- Add Laravel 12 test matrix in GitHub workflow
- Update testbench to support version 10.* for Laravel 12
- Update collision to support version 9.0
- Adjust PHP version constraints:
  - Laravel 10: PHP 8.1+
  - Laravel 11: PHP 8.2+
  - Laravel 12: PHP 8.3 only