### PR TITLE
[Bug} compatibily with Model::shouldBeStrict()

### DIFF
--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -55,7 +55,7 @@ class EditProfileForm extends BaseProfileForm
                             ->visibility(config('filament-edit-profile.visibility', 'public'))
                             ->directory(filament('filament-edit-profile')->getAvatarDirectory())
                             ->rules(filament('filament-edit-profile')->getAvatarRules())
-                            ->hidden(!filament('filament-edit-profile')->getShouldShowAvatarForm()),
+                            ->hidden(! filament('filament-edit-profile')->getShouldShowAvatarForm()),
                         TextInput::make('name')
                             ->label(__('filament-edit-profile::default.name'))
                             ->required(),

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -28,7 +28,15 @@ class EditProfileForm extends BaseProfileForm
 
         $this->userClass = get_class($this->user);
 
-        $this->form->fill($this->user->only(config('filament-edit-profile.avatar_column', 'avatar_url'), 'name', 'email'));
+        $fields = [
+            'name',
+            'email',
+        ];
+        if (filament('filament-edit-profile')->getShouldShowAvatarForm()) {
+            $fields[] = config('filament-edit-profile.avatar_column', 'avatar_url');
+        }
+
+        $this->form->fill($this->user->only($fields));
     }
 
     public function form(Form $form): Form
@@ -47,7 +55,7 @@ class EditProfileForm extends BaseProfileForm
                             ->visibility(config('filament-edit-profile.visibility', 'public'))
                             ->directory(filament('filament-edit-profile')->getAvatarDirectory())
                             ->rules(filament('filament-edit-profile')->getAvatarRules())
-                            ->hidden(! filament('filament-edit-profile')->getShouldShowAvatarForm()),
+                            ->hidden(!filament('filament-edit-profile')->getShouldShowAvatarForm()),
                         TextInput::make('name')
                             ->label(__('filament-edit-profile::default.name'))
                             ->required(),


### PR DESCRIPTION
# Install Laravel

```bash
mkdir -p /path/to/project/laravel
cd /path/to/project/laravel

composer create-project laravel/laravel .

php artisan migrate

composer require livewire/livewire filament/filament

# install admin panel
php artisan filament:install --panels

# create test user (admin)
php artisan make:filament-user --name=Admin --email=admin@mail.com --password=Password123!

# test site
php artisan serve
```

Go to: [http://127.0.0.1:8000/admin]()

# Install Plugin
```bash
composer require joaopaulolndev/filament-edit-profile
```

# Configure Plugin
`app/Providers/Filament/AdminPanelProvider.php`

```diff
<?php

// ...
+use Filament\Navigation\MenuItem;
+use Joaopaulolndev\FilamentEditProfile\FilamentEditProfilePlugin;
+use Joaopaulolndev\FilamentEditProfile\Pages\EditProfilePage;

class AdminPanelProvider extends PanelProvider
{
    public function panel(Panel $panel): Panel
    {
        return $panel
            // ...
+            ->userMenuItems([
+                'profile' => MenuItem::make()
+                    ->label(fn () => auth()->user()->name)
+                    ->url(fn (): string => EditProfilePage::getUrl())
+                    ->icon('heroicon-m-user-circle'),
+            ])
+            ->plugins([
+                FilamentEditProfilePlugin::make()
+                    ->slug('profile')
+                    ->shouldRegisterNavigation(false)
+                    ->shouldShowDeleteAccountForm(false)
+                    ->shouldShowSanctumTokens(false)
+                    ->shouldShowBrowserSessionsForm()
+                    ->shouldShowAvatarForm(false),
+            ])
            // ...
    }
}
```
> [!IMPORTANT] 
> Notice: `->shouldShowAvatarForm(false)`

# Test Plugin
```bash
php artisan serve
```
Go to: [http://127.0.0.1:8000/admin/profile]()

# Change setup Models
`./app/Providers/AppServiceProvider.php`
```diff
<?php

namespace App\Providers;

use Illuminate\Support\ServiceProvider;
+ use Illuminate\Database\Eloquent\Model;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     */
    public function register(): void
    {
        //
    }

    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
+         Model::shouldBeStrict();
+         // Model::unguard();
    }
}
```

Go to: [http://127.0.0.1:8000/admin/profile]()

# Error

It doesn't work, the site throws the exception.
```
[previous exception] [object] (Illuminate\\Database\\Eloquent\\MissingAttributeException(code: 0): The attribute [avatar_url] either does not exist or was not retrieved for model [App\\Models\\User]. at ./laravel/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:506)
[stacktrace]
#0 ./laravel/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(486): Illuminate\\Database\\Eloquent\\Model->throwMissingAttributeExceptionIfApplicable()
#1 ./laravel/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(1984): Illuminate\\Database\\Eloquent\\Model->getAttribute()
#2 ./laravel/vendor/joaopaulolndev/filament-edit-profile/src/Livewire/EditProfileForm.php(31): Illuminate\\Database\\Eloquent\\Model->only()
```
