### PR TITLE
Simplify slug retrieval logic

### DIFF
--- a/src/Pages/EditProfilePage.php
+++ b/src/Pages/EditProfilePage.php
@@ -15,11 +15,7 @@ class EditProfilePage extends Page
     {
         $plugin = Filament::getCurrentPanel()?->getPlugin('filament-edit-profile');
 
-        $slug = $plugin->getSlug();
-
-        $slug = $slug ? $slug : self::$slug;
-
-        return $slug;
+        return $plugin?->getSlug() ?? self::$slug;
     }
 
     public static function shouldRegisterNavigation(): bool


### PR DESCRIPTION
This pull request includes a change to the `getSlug` method in the `EditProfilePage` class to simplify the code and improve readability.

* [`src/Pages/EditProfilePage.php`](diffhunk://#diff-b848aa0cac0c1ad2183bb8cfdbf8c435ce73f7bb5d08f2b45f18180cf3272f87L18-R18): Modified the `getSlug` method to use the null coalescing operator (`??`) instead of multiple lines of conditional checks.