### PR TITLE
feat(profile): add email form visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ use Joaopaulolndev\FilamentEditProfile\FilamentEditProfilePlugin;
         ->setSort(10)
         ->canAccess(fn () => auth()->user()->id === 1)
         ->shouldRegisterNavigation(false)
+        ->shouldShowEmailForm()
         ->shouldShowDeleteAccountForm(false)
         ->shouldShowSanctumTokens()
         ->shouldShowBrowserSessionsForm()

--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -37,6 +37,8 @@ class FilamentEditProfilePlugin implements Plugin
 
     public bool $shouldShowEditProfileForm = true;
 
+    public bool $shouldShowEmailForm = true;
+
     public bool $shouldShowEditPasswordForm = true;
 
     public Closure | bool $shouldShowDeleteAccountForm = true;
@@ -282,6 +284,18 @@ class FilamentEditProfilePlugin implements Plugin
         }
 
         return $this;
+    }
+
+    public function shouldShowEmailForm(Closure | bool $value = true): static
+    {
+        $this->shouldShowEmailForm = $value;
+
+        return $this;
+    }
+
+    public function getShouldShowEmailForm(): bool
+    {
+        return $this->evaluate($this->shouldShowEmailForm);
     }
 
     public function getShouldShowAvatarForm(): bool

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -63,6 +63,7 @@ class EditProfileForm extends BaseProfileForm
                             ->label(__('filament-edit-profile::default.email'))
                             ->email()
                             ->required()
+                            ->hidden(! filament('filament-edit-profile')->getShouldShowEmailForm())
                             ->unique($this->userClass, ignorable: $this->user),
                     ]),
             ])


### PR DESCRIPTION
This pull request introduces functionality to conditionally display an email form in the Filament Edit Profile plugin. The changes include adding a new property, methods to manage its visibility, and integration into the profile form logic.

### New feature: Conditional email form visibility

* `src/FilamentEditProfilePlugin.php`:  
  - Added a new property `shouldShowEmailForm` to control the visibility of the email form.  
  - Introduced `shouldShowEmailForm` and `getShouldShowEmailForm` methods to set and evaluate the visibility condition of the email form.

* `src/Livewire/EditProfileForm.php`:  
  - Updated the email field in the profile form to respect the `shouldShowEmailForm` visibility condition, hiding it when necessary.