### PR TITLE
fix(profile): correct input field to use 'email' instead of auth identifier

### DIFF
--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -28,7 +28,7 @@ class EditProfileForm extends BaseProfileForm
 
         $this->userClass = get_class($this->user);
 
-        $fields = ['name', $this->user->getAuthIdentifierName()];
+        $fields = ['name', 'email'];
 
         if (filament('filament-edit-profile')->getShouldShowAvatarForm()) {
             $fields[] = config('filament-edit-profile.avatar_column', 'avatar_url');
@@ -57,7 +57,7 @@ class EditProfileForm extends BaseProfileForm
                         TextInput::make('name')
                             ->label(__('filament-edit-profile::default.name'))
                             ->required(),
-                        TextInput::make($this->user->getAuthIdentifierName())
+                        TextInput::make('email')
                             ->label(__('filament-edit-profile::default.email'))
                             ->email()
                             ->required()


### PR DESCRIPTION
The user authentication field was incorrectly using the identifier name. Updated the field to explicitly use 'email' to ensure correct profile data handling.