### PR TITLE
fix(profile): handle missing Sanctum class in token visibility logic

### DIFF
--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -248,6 +248,10 @@ class FilamentEditProfilePlugin implements Plugin
 
     public function getShouldShowSanctumTokens(): bool
     {
+        if (! class_exists('Laravel\Sanctum\Sanctum')) {
+            $this->sanctumTokens = false;
+        }
+
         return $this->evaluate($this->sanctumTokens);
     }
 


### PR DESCRIPTION
Ensure `getShouldShowSanctumTokens` correctly disables token visibility when Sanctum is not installed.