### PR TITLE
dirty fix

### DIFF
--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Support\Exceptions\Halt;
+use Illuminate\Support\Facades\Storage;
 use Joaopaulolndev\FilamentEditProfile\Concerns\HasUser;
 
 class EditProfileForm extends BaseProfileForm
@@ -28,7 +29,7 @@ class EditProfileForm extends BaseProfileForm
 
         $this->userClass = get_class($this->user);
 
-        $fields = ['name', $this->user->getAuthIdentifierName()];
+        $fields = ['name', 'email',$this->user->getAuthIdentifierName()];
 
         if (filament('filament-edit-profile')->getShouldShowAvatarForm()) {
             $fields[] = config('filament-edit-profile.avatar_column', 'avatar_url');
@@ -57,7 +58,7 @@ class EditProfileForm extends BaseProfileForm
                         TextInput::make('name')
                             ->label(__('filament-edit-profile::default.name'))
                             ->required(),
-                        TextInput::make($this->user->getAuthIdentifierName())
+                        TextInput::make('email')
                             ->label(__('filament-edit-profile::default.email'))
                             ->email()
                             ->required()

--- a/src/Pages/EditProfilePage.php
+++ b/src/Pages/EditProfilePage.php
@@ -13,9 +13,15 @@ class EditProfilePage extends Page
 
     public static function getSlug(): string
     {
-        $plugin = Filament::getCurrentPanel()?->getPlugin('filament-edit-profile');
-
-        return $plugin?->getSlug() ?? self::$slug;
+        $panel = Filament::getCurrentPanel();
+        if (! $panel) {
+            return static::$slug;
+        }
+        $plugin = $panel->getPlugin('filament-edit-profile');
+        if (! $plugin || ! method_exists($plugin, 'getSlug')) {
+            return static::$slug;
+        }
+        return $plugin->getSlug() ?: static::$slug;
     }
 
     public static function shouldRegisterNavigation(): bool


### PR DESCRIPTION

Context:
Fresh install of Laravel 12, Filament 3, single panel, and using `filament-edit-profile` plugin.

Issues:

1. `email` input was showing the user's ID instead of the email address.
   The default code used:
       $this->user->getAuthIdentifierName()
   Which returned 'id' instead of 'email'. So the fix was to manually use:
       TextInput::make('email')

2. Uploaded avatar files were stored in:
       storage/app/private/avatars/{uuid}.jpg
   But were not being moved to:
       storage/app/public/avatars/{uuid}.jpg

   This caused a 403 Forbidden error when accessing:
       /storage/avatars/{uuid}.jpg

   Temporary Fix:
   In `updateProfile()`, manually move the file if it exists in the private disk:

       if (
           isset($data['avatar_url']) &&
           is_string($data['avatar_url']) &&
           Storage::disk('local')->exists("private/{$data['avatar_url']}")
       ) {
           Storage::disk('local')->move(
               "private/{$data['avatar_url']}",
               "public/{$data['avatar_url']}"
           );
       }

3. The plugin panel slug registration would fail if no panel or plugin was found.
   This updated method solves it:

       public static function getSlug(): string
       {
           $panel = Filament::getCurrentPanel();
           if (! $panel) {
               return static::$slug;
           }

           $plugin = $panel->getPlugin('filament-edit-profile');
           if (! $plugin || ! method_exists($plugin, 'getSlug')) {
               return static::$slug;
           }

           return $plugin->getSlug() ?: static::$slug;
       }

Recommendation:
To ensure future-proof compatibility:
- Use `saveUploadedFileUsing()` inside `FileUpload` to control final file destination.
- Fix incorrect field mapping for inputs like 'email'.
- Ensure panel/slug logic is safe-guarded for multi-panel apps.

Happy to improve this PR further if needed.
