### PR TITLE
Feat: Allow applications to define the field where the email is set in the users table

### DIFF
--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -4,4 +4,5 @@ return [
     'avatar_column' => 'avatar_url',
     'disk' => env('FILESYSTEM_DISK', 'public'),
     'visibility' => 'public', // or replace by filesystem disk visibility with fallback value
+    // 'email' => 'email',
 ];

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -28,7 +28,8 @@ class EditProfileForm extends BaseProfileForm
 
         $this->userClass = get_class($this->user);
 
-        $fields = ['name', $this->user->getAuthIdentifierName()];
+        $emailField = config('filament-edit-profile.email', $this->user->getAuthIdentifierName());
+        $fields = ['name', $emailField];
 
         if (filament('filament-edit-profile')->getShouldShowAvatarForm()) {
             $fields[] = config('filament-edit-profile.avatar_column', 'avatar_url');
@@ -57,7 +58,7 @@ class EditProfileForm extends BaseProfileForm
                         TextInput::make('name')
                             ->label(__('filament-edit-profile::default.name'))
                             ->required(),
-                        TextInput::make($this->user->getAuthIdentifierName())
+                        TextInput::make(config('filament-edit-profile.email', $this->user->getAuthIdentifierName()))
                             ->label(__('filament-edit-profile::default.email'))
                             ->email()
                             ->required()


### PR DESCRIPTION
# Reasoning behind the changes
- I am using the library to manage the profile of user facing filament app (instead of just as an admin panel)

# Changes
- When getting the email field in the EditProfileForm try to get the config defined in `filament-edit-profile.email`, if this is not defined use the current approach `$this->user->getAuthIdentifierName()`