### PR TITLE
Update EditProfilePage.php

### DIFF
--- a/src/Pages/EditProfilePage.php
+++ b/src/Pages/EditProfilePage.php
@@ -15,7 +15,7 @@ class EditProfilePage extends Page
     {
         $plugin = Filament::getCurrentPanel()?->getPlugin('filament-edit-profile');
 
-        $slug = $plugin->getSlug();
+        $slug = $plugin?->getSlug();
 
         return $slug ? $slug : self::$slug;
     }


### PR DESCRIPTION
   Error 

  Call to a member function getSlug() on null

  at vendor\joaopaulolndev\filament-edit-profile\src\Pages\EditProfilePage.php:18
     14▕     public static function getSlug(): string
     15▕     {
     16▕         $plugin = Filament::getCurrentPanel()?->getPlugin('filament-edit-profile');
     17▕
  ➜  18▕         $slug = $plugin->getSlug();
     20▕         return $slug ? $slug : self::$slug;
     21▕     }
     22▕