### PR TITLE
fix: avoid error when plugin is null in getSlug() method

### DIFF
--- a/src/Pages/EditProfilePage.php
+++ b/src/Pages/EditProfilePage.php
@@ -15,7 +15,7 @@ class EditProfilePage extends Page
     {
         $plugin = Filament::getCurrentPanel()?->getPlugin('filament-edit-profile');
 
-        $slug = $plugin->getSlug();
+        $slug = $plugin?->getSlug();
 
         return $slug ? $slug : self::$slug;
     }


### PR DESCRIPTION
Prevent potential null access in getSlug() by using nullsafe operator on getPlugin()


```php

...

 $slug = $plugin?->getSlug();

...


```