### PR TITLE
docs(readme): add usage guide for locale selection in profile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,42 @@ class User extends Authenticatable implements HasAvatar
 
 5. Don't forget to run the command `php artisan storage:link`
 
+## Profile Locale
+
+Show the user locale form using `shouldShowLocaleForm()`.
+
+To show the locale form, you need the following steps:
+
+1. Publish the migration file to add the locale field to the users table:
+
+```bash
+php artisan vendor:publish --tag="filament-edit-profile-locale-migration"
+php artisan migrate
+```
+
+2. Update the options array with the languages you want to show:
+
+```php
+->shouldShowLocaleForm(
+    options: [
+        'pt_BR' => '🇧🇷 Português',
+        'en' => '🇺🇸 Inglês',
+        'es' => '🇪🇸 Espanhol',
+    ],
+)
+```
+
+3. Add in your User model the locale field in the fillable array:
+
+```php
+protected $fillable = [
+    'name',
+    'email',
+    'password',
+    'locale', // or column name according to config('filament-edit-profile.locale_column', 'locale')
+];
+```
+
 ## Sanctum Personal Access tokens
 
 Show the Sanctum token management component:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ return [
 ## Profile Avatar
 
 ![Screenshot of avatar Feature](https://raw.githubusercontent.com/joaopaulolndev/filament-edit-profile/2.x/art/profile-avatar.png)
-Show the user avatar form using `shouldShowAvatarForm()`. This package follows the [Filament user avatar](https://filamentphp.com/docs/3.x/panels/users#setting-up-user-avatars) to manage the avatar.
+Show the user avatar form using `shouldShowAvatarForm()`. This package follows the [Filament user avatar](https://filamentphp.com/docs/4.x/users/overview#setting-up-user-avatars) to manage the avatar.
 
 To show the avatar form, you need the following steps:
 
@@ -454,7 +454,7 @@ return [
 If you need more control over your profile edit fields, you can create a custom component. To make this process easier, just use the artisan command.
 
 > [!NOTE]
-> If you are not confident in using custom components, please review [Filament Docs](https://filamentphp.com/docs/3.x/forms/adding-a-form-to-a-livewire-component)
+> If you are not confident in using custom components, please review [Filament Docs](https://filamentphp.com/docs/4.x/components/form)
 
 ```bash
 php artisan make:edit-profile-form CustomProfileComponent

--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -1,6 +1,12 @@
 <?php
 
 return [
+    'locales' => [
+        'pt_BR' => '🇧🇷 Português',
+        'en' => '🇺🇸 Inglês',
+        'es' => '🇪🇸 Espanhol',
+    ],
+    'locale_column' => 'locale',
     'avatar_column' => 'avatar_url',
     'disk' => env('FILESYSTEM_DISK', 'public'),
     'visibility' => 'public', // or replace by filesystem disk visibility with fallback value

--- a/database/migrations/add_locale_to_users_table.php.stub
+++ b/database/migrations/add_locale_to_users_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string(config('filament-edit-profile.locale_column', 'locale'))->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(config('filament-edit-profile.locale_column', 'locale'));
+        });
+    }
+};

--- a/resources/lang/ar/default.php
+++ b/resources/lang/ar/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'البريد الإلكتروني',
     'avatar' => 'صورة',
     'password' => 'كلمة المرور',
+    'locale' => 'اللغة',
     'update_password' => 'تحديث كلمة المرور',
     'current_password' => 'كلمة المرور الحالية',
     'new_password' => 'كلمة المرور الجديدة',

--- a/resources/lang/cs/default.php
+++ b/resources/lang/cs/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Fotografie',
     'password' => 'Heslo',
+    'locale' => 'Jazyk',
     'update_password' => 'Aktualizovat heslo',
     'current_password' => 'Současné heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/de/default.php
+++ b/resources/lang/de/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-Mail',
     'avatar' => 'Foto',
     'password' => 'Passwort',
+    'locale' => 'Sprache',
     'update_password' => 'Passwort aktualisieren',
     'current_password' => 'Aktuelles Passwort',
     'new_password' => 'Neues Passwort',

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'Email',
     'avatar' => 'Photo',
     'password' => 'Password',
+    'locale' => 'Language',
     'update_password' => 'Update Password',
     'current_password' => 'Current Password',
     'new_password' => 'New Password',

--- a/resources/lang/es/default.php
+++ b/resources/lang/es/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'Correo Electrónico',
     'avatar' => 'Foto',
     'password' => 'Contraseña',
+    'locale' => 'Idioma',
     'update_password' => 'Actualizar Contraseña',
     'current_password' => 'Contraseña actual',
     'new_password' => 'Nueva Contraseña',

--- a/resources/lang/fa/default.php
+++ b/resources/lang/fa/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'ایمیل',
     'avatar' => 'آواتار',
     'password' => 'رمز عبور',
+    'locale' => 'زبان',
     'update_password' => 'بروزرسانی رمز عبور',
     'current_password' => 'رمز عبور فعلی',
     'new_password' => 'رمز عبور جدید',

--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Photo',
     'password' => 'Mot de passe',
+    'locale' => 'Langue',
     'update_password' => 'Mettre à jour le mot de passe',
     'current_password' => 'Mot de passe actuel',
     'new_password' => 'Nouveau mot de passe',

--- a/resources/lang/hu/default.php
+++ b/resources/lang/hu/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Fotó',
     'password' => 'Jelszó',
+    'locale' => 'Nyelv',
     'update_password' => 'Jelszó frissítése',
     'current_password' => 'Jelenlegi jelszó',
     'new_password' => 'Új jelszó',

--- a/resources/lang/id/default.php
+++ b/resources/lang/id/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'Email',
     'avatar' => 'Foto',
     'password' => 'Kata Sandi',
+    'locale' => 'Bahasa',
     'update_password' => 'Perbarui Kata Sandi',
     'current_password' => 'Kata Sandi Saat Ini',
     'new_password' => 'Kata Sandi Baru',

--- a/resources/lang/it/default.php
+++ b/resources/lang/it/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'Email',
     'password' => 'Password',
     'avatar' => 'Avatar',
+    'locale' => 'Lingua',
     'update_password' => 'Aggiorna Password',
     'current_password' => 'Password Attuale',
     'new_password' => 'Nuova Password',

--- a/resources/lang/ja/default.php
+++ b/resources/lang/ja/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'メールアドレス',
     'avatar' => '写真',
     'password' => 'パスワード',
+    'locale' => '言語',
     'update_password' => 'パスワード更新',
     'current_password' => '現在のパスワード',
     'new_password' => '新しいパスワード',

--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Foto',
     'password' => 'Wachtwoord',
+    'locale' => 'Taal',
     'update_password' => 'Wachtwoord Bijwerken',
     'current_password' => 'Huidig Wachtwoord',
     'new_password' => 'Nieuw Wachtwoord',

--- a/resources/lang/pl/default.php
+++ b/resources/lang/pl/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Zdjęcie',
     'password' => 'Hasło',
+    'locale' => 'Język',
     'update_password' => 'Zaktualizuj hasło',
     'current_password' => 'Obecne hasło',
     'new_password' => 'Nowe hasło',

--- a/resources/lang/pt_BR/default.php
+++ b/resources/lang/pt_BR/default.php
@@ -7,6 +7,7 @@ return [
     'name' => 'Nome',
     'email' => 'E-mail',
     'password' => 'Senha',
+    'locale' => 'Idioma',
     'update_password' => 'Atualizar Senha',
     'current_password' => 'Senha Atual',
     'new_password' => 'Nova Senha',

--- a/resources/lang/pt_PT/default.php
+++ b/resources/lang/pt_PT/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'Email',
     'avatar' => 'Foto',
     'password' => 'Palavra-passe',
+    'locale' => 'Idioma',
     'update_password' => 'Atualizar Palavra-passe',
     'current_password' => 'Palavra-passe Atual',
     'new_password' => 'Nova Palavra-passe',

--- a/resources/lang/sk/default.php
+++ b/resources/lang/sk/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'avatar' => 'Fotografia',
     'password' => 'Heslo',
+    'locale' => 'Jazyk',
     'update_password' => 'Aktualizuj heslo',
     'current_password' => 'Aktuálne heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/tr/default.php
+++ b/resources/lang/tr/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-posta',
     'avatar' => 'Fotoğraf',
     'password' => 'Şifre',
+    'locale' => 'Dil',
     'update_password' => 'Şifreyi Güncelle',
     'current_password' => 'Mevcut Şifre',
     'new_password' => 'Yeni Şifre',

--- a/src/Concerns/HasUser.php
+++ b/src/Concerns/HasUser.php
@@ -9,6 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 
 trait HasUser
 {
+    /**
+     * @var Authenticatable & Model
+     */
     public $user;
 
     protected function getUser(): Authenticatable & Model

--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -7,6 +7,7 @@ use Filament\Contracts\Plugin;
 use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
+use Joaopaulolndev\FilamentEditProfile\Http\Middleware\SetUserLocale;
 use Joaopaulolndev\FilamentEditProfile\Livewire\BrowserSessionsForm;
 use Joaopaulolndev\FilamentEditProfile\Livewire\CustomFieldsForm;
 use Joaopaulolndev\FilamentEditProfile\Livewire\DeleteAccountForm;
@@ -41,6 +42,10 @@ class FilamentEditProfilePlugin implements Plugin
 
     public bool $shouldShowEmailForm = true;
 
+    public bool $shouldShowLocaleForm = false;
+
+    public array $localeOptions = [];
+
     public bool $shouldShowEditPasswordForm = true;
 
     public Closure | bool $shouldShowDeleteAccountForm = true;
@@ -69,7 +74,10 @@ class FilamentEditProfilePlugin implements Plugin
     public function register(Panel $panel): void
     {
         $panel
-            ->pages($this->preparePages());
+            ->pages($this->preparePages())
+            ->middleware([
+                SetUserLocale::class . ':' . $panel->getAuthGuard(),
+            ]);
     }
 
     protected function preparePages(): array
@@ -295,6 +303,39 @@ class FilamentEditProfilePlugin implements Plugin
         })->toArray();
     }
 
+    public function shouldShowEmailForm(Closure | bool $value = true): static
+    {
+        $this->shouldShowEmailForm = $value;
+
+        return $this;
+    }
+
+    public function getShouldShowEmailForm(): bool
+    {
+        return $this->evaluate($this->shouldShowEmailForm);
+    }
+
+    public function shouldShowLocaleForm(Closure | bool $value = true, array $options = []): static
+    {
+        if (empty($options)) {
+            $options = config('filament-edit-profile.locales');
+        }
+        $this->localeOptions = $options;
+        $this->shouldShowLocaleForm = $value;
+
+        return $this;
+    }
+
+    public function getShouldShowLocaleForm(): bool
+    {
+        return $this->evaluate($this->shouldShowLocaleForm);
+    }
+
+    public function getOptionsLocaleForm(): array
+    {
+        return $this->evaluate($this->localeOptions);
+    }
+
     public function shouldShowAvatarForm(Closure | bool $value = true, ?string $directory = null, string | array | null $rules = null): static
     {
         $this->shouldShowAvatarForm = $value;
@@ -308,18 +349,6 @@ class FilamentEditProfilePlugin implements Plugin
         }
 
         return $this;
-    }
-
-    public function shouldShowEmailForm(Closure | bool $value = true): static
-    {
-        $this->shouldShowEmailForm = $value;
-
-        return $this;
-    }
-
-    public function getShouldShowEmailForm(): bool
-    {
-        return $this->evaluate($this->shouldShowEmailForm);
     }
 
     public function getShouldShowAvatarForm(): bool

--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -213,7 +213,7 @@ class FilamentEditProfilePlugin implements Plugin
         return $this;
     }
 
-    public function getShouldShowEditePasswordForm(): bool
+    public function getShouldShowEditPasswordForm(): bool
     {
         return $this->evaluate($this->shouldShowEditPasswordForm);
     }
@@ -341,11 +341,11 @@ class FilamentEditProfilePlugin implements Plugin
     {
         $components = collect();
 
-        if ($this->shouldShowEditProfileForm) {
+        if ($this->getShouldShowEditProfileForm()) {
             $components->put('edit_profile_form', EditProfileForm::class);
         }
 
-        if ($this->shouldShowEditPasswordForm) {
+        if ($this->getShouldShowEditPasswordForm()) {
             $components->put('edit_password_form', EditPasswordForm::class);
         }
 

--- a/src/FilamentEditProfileServiceProvider.php
+++ b/src/FilamentEditProfileServiceProvider.php
@@ -66,6 +66,7 @@ class FilamentEditProfileServiceProvider extends PackageServiceProvider
             };
             $publishMigration('add_avatar_url_to_users_table.php', 'filament-edit-profile-avatar-migration');
             $publishMigration('add_custom_fields_to_users_table.php', 'filament-edit-profile-custom-field-migration');
+            $publishMigration('add_locale_to_users_table.php', 'filament-edit-profile-locale-migration');
         }
 
         // Testing
@@ -95,6 +96,7 @@ class FilamentEditProfileServiceProvider extends PackageServiceProvider
         return [
             'add_custom_fields_to_users_table',
             'add_avatar_url_to_users_table',
+            'add_locale_to_users_table',
         ];
     }
 

--- a/src/Http/Middleware/SetUserLocale.php
+++ b/src/Http/Middleware/SetUserLocale.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Joaopaulolndev\FilamentEditProfile\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
+
+class SetUserLocale
+{
+    public function handle(Request $request, Closure $next, ?string $guard = null)
+    {
+        /** @var \Illuminate\Foundation\Auth\User $user */
+        $user = Auth::guard($guard)->user();
+
+        if ($user && filled($user->getAttributeValue('locale'))) {
+            App::setLocale($user->getAttributeValue('locale'));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Livewire/CustomFieldsForm.php
+++ b/src/Livewire/CustomFieldsForm.php
@@ -2,6 +2,7 @@
 
 namespace Joaopaulolndev\FilamentEditProfile\Livewire;
 
+use Closure;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
@@ -12,6 +13,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Exceptions\Halt;
 use Illuminate\Support\Str;
 use Joaopaulolndev\FilamentEditProfile\Concerns\HasUser;
 use Throwable;

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -3,6 +3,7 @@
 namespace Joaopaulolndev\FilamentEditProfile\Livewire;
 
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Section;
@@ -34,6 +35,10 @@ class EditProfileForm extends BaseProfileForm
             $fields[] = config('filament-edit-profile.avatar_column', 'avatar_url');
         }
 
+        if (filament('filament-edit-profile')->getShouldShowLocaleForm()) {
+            $fields[] = config('filament-edit-profile.locale_column', 'locale');
+        }
+
         $this->form->fill($this->user->only($fields));
     }
 
@@ -63,6 +68,11 @@ class EditProfileForm extends BaseProfileForm
                             ->required()
                             ->hidden(! filament('filament-edit-profile')->getShouldShowEmailForm())
                             ->unique($this->userClass, ignorable: $this->user),
+                        Select::make('locale')
+                            ->label(__('filament-edit-profile::default.locale'))
+                            ->options(filament('filament-edit-profile')->getOptionsLocaleForm())
+                            ->required()
+                            ->hidden(! filament('filament-edit-profile')->getShouldShowLocaleForm()),
                     ]),
             ])
             ->statePath('data');
@@ -70,6 +80,11 @@ class EditProfileForm extends BaseProfileForm
 
     public function updateProfile(): void
     {
+        $locale = null;
+        if (filament('filament-edit-profile')->getShouldShowLocaleForm()) {
+            $locale = $this->user->getAttributeValue('locale');
+        }
+
         try {
             $data = $this->form->getState();
 
@@ -84,5 +99,11 @@ class EditProfileForm extends BaseProfileForm
             ->success()
             ->title(__('filament-edit-profile::default.saved_successfully'))
             ->send();
+
+        if (filament('filament-edit-profile')->getShouldShowLocaleForm()) {
+            if ($locale !== $this->user->getAttributeValue('locale')) {
+                redirect(request()->header('referer'));
+            }
+        }
     }
 }


### PR DESCRIPTION
Expanded the documentation to include instructions for enabling and configuring the locale selection form in the profile settings. Detailed the necessary migration, model updates, and usage examples to assist developers with implementation.