### PR TITLE
feat(theme-color): add support for user-configurable theme color

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ use Joaopaulolndev\FilamentEditProfile\FilamentEditProfilePlugin;
                 'es' => '🇪🇸 Espanhol',
             ],
         )
+        ->shouldShowThemeColorForm()
         ->shouldShowDeleteAccountForm(false)
         ->shouldShowSanctumTokens()
         ->shouldShowMultiFactorAuthentication()
@@ -232,6 +233,36 @@ protected $fillable = [
     'email',
     'password',
     'locale', // or column name according to config('filament-edit-profile.locale_column', 'locale')
+];
+```
+
+## Profile Theme Color
+
+Show the user theme_color form using `shouldShowThemeColorForm()`.
+
+To show the theme_color form, you need the following steps:
+
+1. Publish the migration file to add the theme_color field to the users table:
+
+```bash
+php artisan vendor:publish --tag="filament-edit-profile-theme-color-migration"
+php artisan migrate
+```
+
+2. Update the primary color default value:
+
+```php
+->shouldShowThemeColorForm()
+```
+
+3. Add in your User model the locale field in the fillable array:
+
+```php
+protected $fillable = [
+    'name',
+    'email',
+    'password',
+    'theme_color', // or column name according to config('filament-edit-profile.theme_color_column', 'theme_color')
 ];
 ```
 

--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -7,6 +7,7 @@ return [
         'es' => '🇪🇸 Espanhol',
     ],
     'locale_column' => 'locale',
+    'theme_color_column' => 'theme_color',
     'avatar_column' => 'avatar_url',
     'disk' => env('FILESYSTEM_DISK', 'public'),
     'visibility' => 'public', // or replace by filesystem disk visibility with fallback value

--- a/database/migrations/add_theme_color_to_users_table.php.stub
+++ b/database/migrations/add_theme_color_to_users_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string(config('filament-edit-profile.theme_color_column', 'theme_color'))->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(config('filament-edit-profile.theme_color_column', 'theme_color'));
+        });
+    }
+};

--- a/resources/lang/ar/default.php
+++ b/resources/lang/ar/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'صورة',
     'password' => 'كلمة المرور',
     'locale' => 'اللغة',
+        'theme_color' => 'لون السمة',
     'update_password' => 'تحديث كلمة المرور',
     'current_password' => 'كلمة المرور الحالية',
     'new_password' => 'كلمة المرور الجديدة',

--- a/resources/lang/ar/default.php
+++ b/resources/lang/ar/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'صورة',
     'password' => 'كلمة المرور',
     'locale' => 'اللغة',
-        'theme_color' => 'لون السمة',
+    'theme_color' => 'لون السمة',
     'update_password' => 'تحديث كلمة المرور',
     'current_password' => 'كلمة المرور الحالية',
     'new_password' => 'كلمة المرور الجديدة',

--- a/resources/lang/cs/default.php
+++ b/resources/lang/cs/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Fotografie',
     'password' => 'Heslo',
     'locale' => 'Jazyk',
+        'theme_color' => 'Barva motivu',
     'update_password' => 'Aktualizovat heslo',
     'current_password' => 'Současné heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/cs/default.php
+++ b/resources/lang/cs/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Fotografie',
     'password' => 'Heslo',
     'locale' => 'Jazyk',
-        'theme_color' => 'Barva motivu',
+    'theme_color' => 'Barva motivu',
     'update_password' => 'Aktualizovat heslo',
     'current_password' => 'Současné heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/de/default.php
+++ b/resources/lang/de/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Passwort',
     'locale' => 'Sprache',
+        'theme_color' => 'Themenfarbe',
     'update_password' => 'Passwort aktualisieren',
     'current_password' => 'Aktuelles Passwort',
     'new_password' => 'Neues Passwort',

--- a/resources/lang/de/default.php
+++ b/resources/lang/de/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Passwort',
     'locale' => 'Sprache',
-        'theme_color' => 'Themenfarbe',
+    'theme_color' => 'Themenfarbe',
     'update_password' => 'Passwort aktualisieren',
     'current_password' => 'Aktuelles Passwort',
     'new_password' => 'Neues Passwort',

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Photo',
     'password' => 'Password',
     'locale' => 'Language',
+    'theme_color' => 'Theme Color',
     'update_password' => 'Update Password',
     'current_password' => 'Current Password',
     'new_password' => 'New Password',

--- a/resources/lang/es/default.php
+++ b/resources/lang/es/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Contraseña',
     'locale' => 'Idioma',
+        'theme_color' => 'Color del tema',
     'update_password' => 'Actualizar Contraseña',
     'current_password' => 'Contraseña actual',
     'new_password' => 'Nueva Contraseña',

--- a/resources/lang/es/default.php
+++ b/resources/lang/es/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Contraseña',
     'locale' => 'Idioma',
-        'theme_color' => 'Color del tema',
+    'theme_color' => 'Color del tema',
     'update_password' => 'Actualizar Contraseña',
     'current_password' => 'Contraseña actual',
     'new_password' => 'Nueva Contraseña',

--- a/resources/lang/fa/default.php
+++ b/resources/lang/fa/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'آواتار',
     'password' => 'رمز عبور',
     'locale' => 'زبان',
-        'theme_color' => 'رنگ تم',
+    'theme_color' => 'رنگ تم',
     'update_password' => 'بروزرسانی رمز عبور',
     'current_password' => 'رمز عبور فعلی',
     'new_password' => 'رمز عبور جدید',

--- a/resources/lang/fa/default.php
+++ b/resources/lang/fa/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'آواتار',
     'password' => 'رمز عبور',
     'locale' => 'زبان',
+        'theme_color' => 'رنگ تم',
     'update_password' => 'بروزرسانی رمز عبور',
     'current_password' => 'رمز عبور فعلی',
     'new_password' => 'رمز عبور جدید',

--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Photo',
     'password' => 'Mot de passe',
     'locale' => 'Langue',
+        'theme_color' => 'Couleur du thème',
     'update_password' => 'Mettre à jour le mot de passe',
     'current_password' => 'Mot de passe actuel',
     'new_password' => 'Nouveau mot de passe',

--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Photo',
     'password' => 'Mot de passe',
     'locale' => 'Langue',
-        'theme_color' => 'Couleur du thème',
+    'theme_color' => 'Couleur du thème',
     'update_password' => 'Mettre à jour le mot de passe',
     'current_password' => 'Mot de passe actuel',
     'new_password' => 'Nouveau mot de passe',

--- a/resources/lang/hu/default.php
+++ b/resources/lang/hu/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Fotó',
     'password' => 'Jelszó',
     'locale' => 'Nyelv',
+        'theme_color' => 'Témaszín',
     'update_password' => 'Jelszó frissítése',
     'current_password' => 'Jelenlegi jelszó',
     'new_password' => 'Új jelszó',

--- a/resources/lang/hu/default.php
+++ b/resources/lang/hu/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Fotó',
     'password' => 'Jelszó',
     'locale' => 'Nyelv',
-        'theme_color' => 'Témaszín',
+    'theme_color' => 'Témaszín',
     'update_password' => 'Jelszó frissítése',
     'current_password' => 'Jelenlegi jelszó',
     'new_password' => 'Új jelszó',

--- a/resources/lang/id/default.php
+++ b/resources/lang/id/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Kata Sandi',
     'locale' => 'Bahasa',
+        'theme_color' => 'Warna Tema',
     'update_password' => 'Perbarui Kata Sandi',
     'current_password' => 'Kata Sandi Saat Ini',
     'new_password' => 'Kata Sandi Baru',

--- a/resources/lang/id/default.php
+++ b/resources/lang/id/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Kata Sandi',
     'locale' => 'Bahasa',
-        'theme_color' => 'Warna Tema',
+    'theme_color' => 'Warna Tema',
     'update_password' => 'Perbarui Kata Sandi',
     'current_password' => 'Kata Sandi Saat Ini',
     'new_password' => 'Kata Sandi Baru',

--- a/resources/lang/it/default.php
+++ b/resources/lang/it/default.php
@@ -9,6 +9,7 @@ return [
     'password' => 'Password',
     'avatar' => 'Avatar',
     'locale' => 'Lingua',
+        'theme_color' => 'Colore del tema',
     'update_password' => 'Aggiorna Password',
     'current_password' => 'Password Attuale',
     'new_password' => 'Nuova Password',

--- a/resources/lang/it/default.php
+++ b/resources/lang/it/default.php
@@ -9,7 +9,7 @@ return [
     'password' => 'Password',
     'avatar' => 'Avatar',
     'locale' => 'Lingua',
-        'theme_color' => 'Colore del tema',
+    'theme_color' => 'Colore del tema',
     'update_password' => 'Aggiorna Password',
     'current_password' => 'Password Attuale',
     'new_password' => 'Nuova Password',

--- a/resources/lang/ja/default.php
+++ b/resources/lang/ja/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => '写真',
     'password' => 'パスワード',
     'locale' => '言語',
-        'theme_color' => 'テーマカラー',
+    'theme_color' => 'テーマカラー',
     'update_password' => 'パスワード更新',
     'current_password' => '現在のパスワード',
     'new_password' => '新しいパスワード',

--- a/resources/lang/ja/default.php
+++ b/resources/lang/ja/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => '写真',
     'password' => 'パスワード',
     'locale' => '言語',
+        'theme_color' => 'テーマカラー',
     'update_password' => 'パスワード更新',
     'current_password' => '現在のパスワード',
     'new_password' => '新しいパスワード',

--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Wachtwoord',
     'locale' => 'Taal',
-        'theme_color' => 'Themakleur',
+    'theme_color' => 'Themakleur',
     'update_password' => 'Wachtwoord Bijwerken',
     'current_password' => 'Huidig Wachtwoord',
     'new_password' => 'Nieuw Wachtwoord',

--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Wachtwoord',
     'locale' => 'Taal',
+        'theme_color' => 'Themakleur',
     'update_password' => 'Wachtwoord Bijwerken',
     'current_password' => 'Huidig Wachtwoord',
     'new_password' => 'Nieuw Wachtwoord',

--- a/resources/lang/pl/default.php
+++ b/resources/lang/pl/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Zdjęcie',
     'password' => 'Hasło',
     'locale' => 'Język',
+        'theme_color' => 'Kolor motywu',
     'update_password' => 'Zaktualizuj hasło',
     'current_password' => 'Obecne hasło',
     'new_password' => 'Nowe hasło',

--- a/resources/lang/pl/default.php
+++ b/resources/lang/pl/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Zdjęcie',
     'password' => 'Hasło',
     'locale' => 'Język',
-        'theme_color' => 'Kolor motywu',
+    'theme_color' => 'Kolor motywu',
     'update_password' => 'Zaktualizuj hasło',
     'current_password' => 'Obecne hasło',
     'new_password' => 'Nowe hasło',

--- a/resources/lang/pt_BR/default.php
+++ b/resources/lang/pt_BR/default.php
@@ -8,6 +8,7 @@ return [
     'email' => 'E-mail',
     'password' => 'Senha',
     'locale' => 'Idioma',
+        'theme_color' => 'Cor do tema',
     'update_password' => 'Atualizar Senha',
     'current_password' => 'Senha Atual',
     'new_password' => 'Nova Senha',

--- a/resources/lang/pt_BR/default.php
+++ b/resources/lang/pt_BR/default.php
@@ -8,7 +8,7 @@ return [
     'email' => 'E-mail',
     'password' => 'Senha',
     'locale' => 'Idioma',
-        'theme_color' => 'Cor do tema',
+    'theme_color' => 'Cor do tema',
     'update_password' => 'Atualizar Senha',
     'current_password' => 'Senha Atual',
     'new_password' => 'Nova Senha',

--- a/resources/lang/pt_PT/default.php
+++ b/resources/lang/pt_PT/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Palavra-passe',
     'locale' => 'Idioma',
+        'theme_color' => 'Cor do tema',
     'update_password' => 'Atualizar Palavra-passe',
     'current_password' => 'Palavra-passe Atual',
     'new_password' => 'Nova Palavra-passe',

--- a/resources/lang/pt_PT/default.php
+++ b/resources/lang/pt_PT/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Foto',
     'password' => 'Palavra-passe',
     'locale' => 'Idioma',
-        'theme_color' => 'Cor do tema',
+    'theme_color' => 'Cor do tema',
     'update_password' => 'Atualizar Palavra-passe',
     'current_password' => 'Palavra-passe Atual',
     'new_password' => 'Nova Palavra-passe',

--- a/resources/lang/sk/default.php
+++ b/resources/lang/sk/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Fotografia',
     'password' => 'Heslo',
     'locale' => 'Jazyk',
-        'theme_color' => 'Farba témy',
+    'theme_color' => 'Farba témy',
     'update_password' => 'Aktualizuj heslo',
     'current_password' => 'Aktuálne heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/sk/default.php
+++ b/resources/lang/sk/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Fotografia',
     'password' => 'Heslo',
     'locale' => 'Jazyk',
+        'theme_color' => 'Farba témy',
     'update_password' => 'Aktualizuj heslo',
     'current_password' => 'Aktuálne heslo',
     'new_password' => 'Nové heslo',

--- a/resources/lang/tr/default.php
+++ b/resources/lang/tr/default.php
@@ -9,7 +9,7 @@ return [
     'avatar' => 'Fotoğraf',
     'password' => 'Şifre',
     'locale' => 'Dil',
-        'theme_color' => 'Tema rengi',
+    'theme_color' => 'Tema rengi',
     'update_password' => 'Şifreyi Güncelle',
     'current_password' => 'Mevcut Şifre',
     'new_password' => 'Yeni Şifre',

--- a/resources/lang/tr/default.php
+++ b/resources/lang/tr/default.php
@@ -9,6 +9,7 @@ return [
     'avatar' => 'Fotoğraf',
     'password' => 'Şifre',
     'locale' => 'Dil',
+        'theme_color' => 'Tema rengi',
     'update_password' => 'Şifreyi Güncelle',
     'current_password' => 'Mevcut Şifre',
     'new_password' => 'Yeni Şifre',

--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Joaopaulolndev\FilamentEditProfile\Http\Middleware\SetUserLocale;
+use Joaopaulolndev\FilamentEditProfile\Http\Middleware\SetUserThemeColor;
 use Joaopaulolndev\FilamentEditProfile\Livewire\BrowserSessionsForm;
 use Joaopaulolndev\FilamentEditProfile\Livewire\CustomFieldsForm;
 use Joaopaulolndev\FilamentEditProfile\Livewire\DeleteAccountForm;
@@ -46,6 +47,8 @@ class FilamentEditProfilePlugin implements Plugin
 
     public array $localeOptions = [];
 
+    public bool $shouldShowThemeColorForm = false;
+
     public bool $shouldShowEditPasswordForm = true;
 
     public Closure | bool $shouldShowDeleteAccountForm = true;
@@ -76,13 +79,13 @@ class FilamentEditProfilePlugin implements Plugin
         $panel
             ->pages($this->preparePages())
             ->middleware([
+                SetUserThemeColor::class . ':' . $panel->getAuthGuard(),
                 SetUserLocale::class . ':' . $panel->getAuthGuard(),
             ]);
     }
 
     protected function preparePages(): array
     {
-
         return [
             EditProfilePage::class,
         ];
@@ -334,6 +337,18 @@ class FilamentEditProfilePlugin implements Plugin
     public function getOptionsLocaleForm(): array
     {
         return $this->evaluate($this->localeOptions);
+    }
+
+    public function shouldShowThemeColorForm(Closure | bool $value = true): static
+    {
+        $this->shouldShowThemeColorForm = $value;
+
+        return $this;
+    }
+
+    public function getShouldShowThemeColorForm(): bool
+    {
+        return $this->evaluate($this->shouldShowThemeColorForm);
     }
 
     public function shouldShowAvatarForm(Closure | bool $value = true, ?string $directory = null, string | array | null $rules = null): static

--- a/src/FilamentEditProfileServiceProvider.php
+++ b/src/FilamentEditProfileServiceProvider.php
@@ -67,6 +67,7 @@ class FilamentEditProfileServiceProvider extends PackageServiceProvider
             $publishMigration('add_avatar_url_to_users_table.php', 'filament-edit-profile-avatar-migration');
             $publishMigration('add_custom_fields_to_users_table.php', 'filament-edit-profile-custom-field-migration');
             $publishMigration('add_locale_to_users_table.php', 'filament-edit-profile-locale-migration');
+            $publishMigration('add_theme_color_to_users_table.php', 'filament-edit-profile-theme-color-migration');
         }
 
         // Testing
@@ -97,6 +98,7 @@ class FilamentEditProfileServiceProvider extends PackageServiceProvider
             'add_custom_fields_to_users_table',
             'add_avatar_url_to_users_table',
             'add_locale_to_users_table',
+            'add_theme_color_to_users_table',
         ];
     }
 

--- a/src/Http/Middleware/SetUserLocale.php
+++ b/src/Http/Middleware/SetUserLocale.php
@@ -13,9 +13,10 @@ class SetUserLocale
     {
         /** @var \Illuminate\Foundation\Auth\User $user */
         $user = Auth::guard($guard)->user();
+        $locale = config('filament-edit-profile.locale_column', 'locale');
 
-        if ($user && filled($user->getAttributeValue('locale'))) {
-            App::setLocale($user->getAttributeValue('locale'));
+        if ($user && filled($user->getAttributeValue($locale))) {
+            App::setLocale($user->getAttributeValue($locale));
         }
 
         return $next($request);

--- a/src/Http/Middleware/SetUserThemeColor.php
+++ b/src/Http/Middleware/SetUserThemeColor.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Joaopaulolndev\FilamentEditProfile\Http\Middleware;
+
+use Closure;
+use Filament\Support\Facades\FilamentColor;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SetUserThemeColor
+{
+    public function handle(Request $request, Closure $next, ?string $guard = null)
+    {
+        /** @var \Illuminate\Foundation\Auth\User $user */
+        $user = Auth::guard($guard)->user();
+        $theme_color = config('filament-edit-profile.theme_color_column', 'theme_color');
+
+        if ($user && filled($user->getAttributeValue($theme_color))) {
+            FilamentColor::register([
+                'primary' => $user->getAttributeValue($theme_color),
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -2,6 +2,7 @@
 
 namespace Joaopaulolndev\FilamentEditProfile\Livewire;
 
+use Filament\Forms\Components\ColorPicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -39,6 +40,10 @@ class EditProfileForm extends BaseProfileForm
             $fields[] = config('filament-edit-profile.locale_column', 'locale');
         }
 
+        if (filament('filament-edit-profile')->getShouldShowThemeColorForm()) {
+            $fields[] = config('filament-edit-profile.theme_color_column', 'theme_color');
+        }
+
         $this->form->fill($this->user->only($fields));
     }
 
@@ -73,6 +78,10 @@ class EditProfileForm extends BaseProfileForm
                             ->options(filament('filament-edit-profile')->getOptionsLocaleForm())
                             ->required()
                             ->hidden(! filament('filament-edit-profile')->getShouldShowLocaleForm()),
+                        ColorPicker::make('theme_color')
+                            ->label(__('filament-edit-profile::default.theme_color'))
+                            ->required()
+                            ->hidden(! filament('filament-edit-profile')->getShouldShowLocaleForm()),
                     ]),
             ])
             ->statePath('data');
@@ -81,8 +90,12 @@ class EditProfileForm extends BaseProfileForm
     public function updateProfile(): void
     {
         $locale = null;
+        $theme_color = null;
         if (filament('filament-edit-profile')->getShouldShowLocaleForm()) {
             $locale = $this->user->getAttributeValue('locale');
+        }
+        if (filament('filament-edit-profile')->getShouldShowThemeColorForm()) {
+            $theme_color = $this->user->getAttributeValue('theme_color');
         }
 
         try {
@@ -102,6 +115,13 @@ class EditProfileForm extends BaseProfileForm
 
         if (filament('filament-edit-profile')->getShouldShowLocaleForm()) {
             if ($locale !== $this->user->getAttributeValue('locale')) {
+                redirect(request()->header('referer'));
+
+                return;
+            }
+        }
+        if (filament('filament-edit-profile')->getShouldShowThemeColorForm()) {
+            if ($theme_color !== $this->user->getAttributeValue('theme_color')) {
                 redirect(request()->header('referer'));
             }
         }


### PR DESCRIPTION
Introduce `SetUserThemeColor` middleware to register the user's theme color dynamically. Added support for showing and saving the `theme_color` field via a form, configurable through `shouldShowThemeColorForm()`. Includes migration, updated translations, and documentation to guide users with enabling and utilizing this feature.