### PR TITLE
fix(theme-color): use the correct getter to show/hide the theme_color field

### DIFF
--- a/src/Livewire/EditProfileForm.php
+++ b/src/Livewire/EditProfileForm.php
@@ -81,7 +81,7 @@ class EditProfileForm extends BaseProfileForm
                         ColorPicker::make('theme_color')
                             ->label(__('filament-edit-profile::default.theme_color'))
                             ->required()
-                            ->hidden(! filament('filament-edit-profile')->getShouldShowLocaleForm()),
+                            ->hidden(! filament('filament-edit-profile')->getShouldShowThemeColorForm()),
                     ]),
             ])
             ->statePath('data');


### PR DESCRIPTION
Changed `getShouldShowLocaleForm` to `getShouldShowThemeColorForm` in the `EditProfileForm` component to control the visibility in the `theme_color` field.