### PR TITLE
feat(profile): add email change verification logic

### DIFF
--- a/src/FilamentEditProfileServiceProvider.php
+++ b/src/FilamentEditProfileServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Joaopaulolndev\FilamentEditProfile;
 
+use Filament\Auth\Http\Responses\Contracts\EmailChangeVerificationResponse as EmailChangeVerificationResponseContract;
 use Joaopaulolndev\FilamentEditProfile\Commands\FilamentEditProfileCommand;
+use Joaopaulolndev\FilamentEditProfile\Http\Responses\EmailChangeVerificationResponse;
 use Joaopaulolndev\FilamentEditProfile\Testing\TestsFilamentEditProfile;
 use Livewire\Features\SupportTesting\Testable;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
@@ -51,7 +53,10 @@ class FilamentEditProfileServiceProvider extends PackageServiceProvider
         }
     }
 
-    public function packageRegistered(): void {}
+    public function packageRegistered(): void
+    {
+        $this->app->bind(EmailChangeVerificationResponseContract::class, EmailChangeVerificationResponse::class);
+    }
 
     public function packageBooted(): void
     {

--- a/src/Http/Responses/EmailChangeVerificationResponse.php
+++ b/src/Http/Responses/EmailChangeVerificationResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Joaopaulolndev\FilamentEditProfile\Http\Responses;
+
+use Filament\Auth\Http\Responses\Contracts\EmailChangeVerificationResponse as Responsable;
+use Filament\Facades\Filament;
+use Illuminate\Http\RedirectResponse;
+use Joaopaulolndev\FilamentEditProfile\Pages\EditProfilePage;
+use Livewire\Features\SupportRedirects\Redirector;
+
+class EmailChangeVerificationResponse implements Responsable
+{
+    public function toResponse($request): RedirectResponse | Redirector
+    {
+        return redirect()->intended(EditProfilePage::getUrl() ?? Filament::getUrl());
+    }
+}


### PR DESCRIPTION
Introduce email change verification functionality in `EditProfileForm`. Includes sending verification emails, handling notifications, and persisting changes securely.