### PR TITLE
Remove default locale options from configuration

### DIFF
--- a/config/filament-edit-profile.php
+++ b/config/filament-edit-profile.php
@@ -1,11 +1,6 @@
 <?php
 
 return [
-    'locales' => [
-        'pt_BR' => '🇧🇷 Português',
-        'en' => '🇺🇸 Inglês',
-        'es' => '🇪🇸 Espanhol',
-    ],
     'locale_column' => 'locale',
     'theme_color_column' => 'theme_color',
     'avatar_column' => 'avatar_url',

--- a/src/FilamentEditProfilePlugin.php
+++ b/src/FilamentEditProfilePlugin.php
@@ -321,7 +321,7 @@ class FilamentEditProfilePlugin implements Plugin
     public function shouldShowLocaleForm(Closure | bool $value = true, array $options = []): static
     {
         if (empty($options)) {
-            $options = config('filament-edit-profile.locales');
+            $value = false;
         }
         $this->localeOptions = $options;
         $this->shouldShowLocaleForm = $value;


### PR DESCRIPTION
Refactor the locale configuration to eliminate default locales. Adjust logic to ensure locale options are appropriately disabled when the provided array is empty.