### PR TITLE
Fix panel fallback for plugin slug retrieval

### DIFF
--- a/src/Pages/EditProfilePage.php
+++ b/src/Pages/EditProfilePage.php
@@ -14,7 +14,11 @@ class EditProfilePage extends Page
 
     public static function getSlug(?Panel $panel = null): string
     {
-        $plugin = Filament::getCurrentOrDefaultPanel()?->getPlugin('filament-edit-profile');
+        if ($panel === null) {
+            $panel = Filament::getCurrentOrDefaultPanel();
+        }
+
+        $plugin = $panel?->getPlugin('filament-edit-profile');
 
         $slug = $plugin?->getSlug();
 


### PR DESCRIPTION
Ensure a default panel is assigned when the panel parameter is null, resolving potential errors in plugin slug retrieval.